### PR TITLE
Revert "packaging: only recommend ipa-client"

### DIFF
--- a/ovirt-host.spec
+++ b/ovirt-host.spec
@@ -2,7 +2,7 @@
 
 Name:		ovirt-host
 Version:	4.5.0
-Release:	0.3%{?release_suffix}%{?dist}
+Release:	0.4%{?release_suffix}%{?dist}
 Summary:	Track required packages for oVirt hosts
 License:	ASL 2.0
 URL:		https://www.ovirt.org/
@@ -54,8 +54,7 @@ Requires:	mailx
 Requires:	NetworkManager-config-server
 
 # from https://bugzilla.redhat.com/show_bug.cgi?id=1490041
-# only recommending from https://bugzilla.redhat.com/show_bug.cgi?id=2017681
-Recommends:	ipa-client
+Requires:	ipa-client
 
 # Hardening packages - from https://bugzilla.redhat.com/show_bug.cgi?id=1598318
 Requires:	openscap


### PR DESCRIPTION


## Changes introduced with this PR

This reverts commit d7431ab48c210d91f8fcc86ed8bfa04fb52e4b51.

It has been decided to close wontfix BZ#2017681
so reverting the requirement to move ipa-client from mandatory to
optional.

The SCAP guide will be fixed for not requiring ipa-client to be absent
on the system.

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y/n] yes