### PR TITLE
FIX: collectd-virt plugin doesn't work with latest libvirt

### DIFF
--- a/ovirt-host.spec
+++ b/ovirt-host.spec
@@ -97,15 +97,15 @@ This meta package pulls in all the dependencies needed for an oVirt hosts.
 Summary:	This meta package pulls in all the dependencies needed for minimal oVirt hosts
 %ifnarch s390x
 # Not available for s390x yet
-Requires:	collectd
-Requires:	collectd-disk
-Requires:	collectd-netlink
-Requires:	collectd-write_http
-Requires:	collectd-virt
+Requires:	collectd >= 5.12.0-7
+Requires:	collectd-disk >= 5.12.0-7
+Requires:	collectd-netlink >= 5.12.0-7
+Requires:	collectd-write_http >= 5.12.0-7
+Requires:	collectd-virt >= 5.12.0-7
 
 %if 0%{?rhel}
 # collectd-write_syslog is available only on RHEL and similar
-Requires:	collectd-write_syslog
+Requires:	collectd-write_syslog >= 5.12.0-7
 %endif
 
 %endif


### PR DESCRIPTION
Upgrade collectd version to 5.12.0-7 minimum

Bug-Url: https://bugzilla.redhat.com/1868372
Signed-off-by: Aviv Litman <alitman@redhat.com>